### PR TITLE
Reduce package size by stripping internal type definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sigsign/hn-search",
-  "version": "0.2.0",
+  "version": "0.3.0-dev",
   "description": "A JavaScript client to search Hacker News content using the hn.algolia.com API.",
   "repository": {
     "type": "git",

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -10,6 +10,9 @@ import type {
 const IntegerSchema = v.pipe(v.number(), v.integer());
 const TimestampSchema = v.pipe(v.string(), v.isoTimestamp());
 
+/**
+ * @internal
+ */
 export const HighlightResultSchema = v.object({
   value: v.string(),
   matchLevel: v.picklist(["none", "partial", "full"]),
@@ -17,6 +20,9 @@ export const HighlightResultSchema = v.object({
   fullyHighlighted: v.optional(v.boolean()),
 });
 
+/**
+ * @internal
+ */
 export const HackerNewsStorySchema = v.object({
   _highlightResult: v.object({
     author: HighlightResultSchema,
@@ -37,6 +43,9 @@ export const HackerNewsStorySchema = v.object({
   url: v.optional(v.pipe(v.string(), v.url())),
 });
 
+/**
+ * @internal
+ */
 export const HackerNewsCommentSchema = v.object({
   _highlightResult: v.object({
     author: HighlightResultSchema,
@@ -58,6 +67,9 @@ export const HackerNewsCommentSchema = v.object({
   updated_at: TimestampSchema,
 });
 
+/**
+ * @internal
+ */
 export const HackerNewsPollSchema = v.object({
   _highlightResult: v.object({
     author: HighlightResultSchema,
@@ -75,6 +87,9 @@ export const HackerNewsPollSchema = v.object({
   updated_at: TimestampSchema,
 });
 
+/**
+ * @internal
+ */
 export const HackerNewsPollOptionSchema = v.object({
   _highlightResult: v.strictObject({
     author: HighlightResultSchema,
@@ -88,7 +103,8 @@ export const HackerNewsPollOptionSchema = v.object({
 });
 
 /**
- * ref: https://www.algolia.com/doc/api-reference/api-methods/search/
+ * @see: https://www.algolia.com/doc/api-reference/api-methods/search/
+ * @internal
  */
 export const SearchResultSchema = v.object({
   exhaustive: v.object({

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -9,6 +9,7 @@
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
+    "stripInternal": true,
     "rootDir": "src",
     "outDir": "dist"
   }


### PR DESCRIPTION
Type definitions for internal Valibot schemas, which were not intended for public use, were being included in `dist/validate.d.ts`.

### Background

- Valibot schemas in `src/validate.ts` are exported mainly for testing purposes.
- These schemas are intended for internal use only.
- Previously, the TypeScript compiler (`tsc`) included their type definitions in the generated `dist/validate.d.ts`, unnecessarily increasing the package size.

### Solution

To prevent these internal type definitions from being emitted and to reduce the package size:

1. The `stripInternal` option was enabled in `tsconfig.json`.
2. The internal schemas in `src/validate.ts` were marked with the `/* @internal */` JSDoc tag.

### Result

As a result, `tsc` no longer outputs the type definitions for these internal schemas in `dist/validate.d.ts`, resulting in a smaller npm package.